### PR TITLE
Fix YouTube URLEncoding the subtitle

### DIFF
--- a/Youtube-Auto-Subtitle-Downloader/Tampermonkey.js
+++ b/Youtube-Auto-Subtitle-Downloader/Tampermonkey.js
@@ -135,6 +135,8 @@ function get_subtitle(){
             result = result.replace(/&gt;/g, '>');
             result = result.replace(/&#39;/g, "'");
             a = escape(result);
+            /* Somehow YouTube have decided to encode their subtitle. We need to decode it. */
+            a = decodeURIComponent(a);
         }
     });
     return a;


### PR DESCRIPTION
Somehow the script is outputing things like

```
1%0D%0A00%3A00%3A43%2C160%20--%3E%2000%3A00%3A46%2C160%20%0D%0Ahello%20everyone%0D%0A%0D%0A2%0D%0A00%3A00%3A46%2C730%20--%3E%2000%3A00%3A54%2C559%20%0D%0Aso%20welcome%20to%20this%20class%20Master%20de%0Avector%20calculus%20and%20on%20a%20board%0D%0A%0D%0A3%0D%0A00%3A00%3A54%2C559%20--%3E%
```

So I added a `decodeURIComponent` to fix the issue.
